### PR TITLE
Set callback url during oauth flow

### DIFF
--- a/neuhatch/config.py
+++ b/neuhatch/config.py
@@ -13,7 +13,8 @@ class Config:
         self.access_token_secret = None
         self.app_secret = None
         self.database_url = None
-        self.hostname = "http://localhost:5000/"
+        self.hostname = "http://localhost:5000"
+
     def environ_set(self):
         self.set_with_warning("consumer_key")
         self.set_with_warning("consumer_secret")
@@ -27,5 +28,3 @@ class Config:
         setattr(self, var, val)
         if getattr(self, var) is None:
             print "Warning %s is None" % var
-
-

--- a/neuhatch/utils.py
+++ b/neuhatch/utils.py
@@ -3,8 +3,9 @@ import tweepy, sys, json
 from flask.ext.login import logout_user, logout_user, login_required, current_user
 from neuhatch import config, app, db, login_manager
 
-def get_base_auth():
-    return tweepy.OAuthHandler(config.consumer_key, config.consumer_secret)
+def get_base_auth(callback_url = None):
+    return tweepy.OAuthHandler(
+        config.consumer_key, config.consumer_secret, callback_url)
 
 def verify_api(request_token, verifier):
     """

--- a/neuhatch/views.py
+++ b/neuhatch/views.py
@@ -34,13 +34,9 @@ def users():
 @app.route("/oauth")
 def oauth():
     try:
-        # TODO: abstract callback url to config
-        callback_url = "%s%s" % ("http://localhost:5000", url_for("callback"))
-        # create initial tweepy callback object
-        auth = utils.get_base_auth()
-        # get redirect url
+        callback_url = "%s%s" % (config.hostname, url_for("callback"))
+        auth = utils.get_base_auth(callback_url)
         redirect_url = auth.get_authorization_url()
-        # set request token
         session['request_token'] = auth.request_token
         return redirect(redirect_url)
     except tweepy.TweepError as e:
@@ -99,4 +95,3 @@ def search():
     for result in results:
         output.append(result._json)
     return utils.json_response(output)
-


### PR DESCRIPTION
Dynamically Sets the callback url that Twitter redirects the user to after they sign in to Twitter.

Twitter will use this url during the oauth flow, instead of using the url associated with the consumer key/secret.
